### PR TITLE
deps: bump aiohttp to 3.14.0 (2 medium security fixes)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.13.4
+aiohttp==3.14.0
 blueskysocial==2.1.0
 tweepy==4.16.0
 facebook-sdk==3.1.0


### PR DESCRIPTION
Fixes both open Dependabot alerts on aiohttp (`< 3.14.0`):
- GHSA-hg6j-4rv6-33pg — cross-origin redirect with per-request cookies (medium)
- GHSA-jg22-mg44-37j8 — deserialization of untrusted data (medium)

Both patched in 3.14.0 (also current latest). Minor bump; aiohttp 3.14.0 installs + imports clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)