### PR TITLE
deps: bump aiohttp 3.14.0 → 3.14.1 (security)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.14.0
+aiohttp==3.14.1
 blueskysocial==2.1.0
 tweepy==4.16.0
 facebook-sdk==3.1.0


### PR DESCRIPTION
Patch bump clearing all **8 open aiohttp security alerts** (5 medium, 3 low), each first-patched in 3.14.1: HTTP/1 pipelined-request queue, C HTTP parser max_line_size bypass, websocket frame memory bypass, DigestAuth cross-origin credential leak, unread compressed body bypass, TLS hostname override, host-only cookie promotion, mid-body payload resource leak.

Patch-level only, no API change. `import aiohttp` + public API (ClientSession/ClientTimeout/ClientError — the surface this repo uses) verified locally on 3.14.1.

Note: this repo has no `.github/dependabot.yml`, which is why no Dependabot PR was raised for these alerts.